### PR TITLE
Add support for JSONL formatted feeds

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.7
 toolchain go1.23.4
 
 require (
-	github.com/ebarkie/netaggr v1.3.3
+	github.com/ebarkie/netaggr v1.3.9
 	github.com/golang/protobuf v1.5.3
 	github.com/osrg/gobgp/v3 v3.32.0
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,8 @@ github.com/eapache/channels v1.1.0 h1:F1taHcn7/F0i8DYqKXJnyhJcVpp2kgFcNePxXtnyu4
 github.com/eapache/channels v1.1.0/go.mod h1:jMm2qB5Ubtg9zLd+inMZd2/NUvXgzmWXsDaLyQIGfH0=
 github.com/eapache/queue v1.1.0 h1:YOEu7KNc61ntiQlcEeUIoDTJ2o8mQznoNvUhiigpIqc=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
-github.com/ebarkie/netaggr v1.3.3 h1:YXvsoSokMhh51iMHdexgGWDU/cE/OFz//b9ZOQ4Og/E=
-github.com/ebarkie/netaggr v1.3.3/go.mod h1:y1qSgnqXXH+UHFRcwgEYEt6yDK8yNc3r6uiX4KAdIAc=
+github.com/ebarkie/netaggr v1.3.9 h1:wtBE88jWyDrWERl4NvieV3+bwOHhOM0vJLAACrF8VRw=
+github.com/ebarkie/netaggr v1.3.9/go.mod h1:o7CZu4wVQE+jVIFIuRRsW+IC4fc4n1ZkwsP7HBNGJyk=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/gobgp.go
+++ b/gobgp.go
@@ -11,13 +11,13 @@ import (
 	"slices"
 	"time"
 
-	"google.golang.org/protobuf/types/known/anypb"
 	"github.com/golang/protobuf/ptypes/any"
 	api "github.com/osrg/gobgp/v3/api"
 	gobgpconfig "github.com/osrg/gobgp/v3/pkg/config"
 	"github.com/osrg/gobgp/v3/pkg/config/oc"
 	"github.com/osrg/gobgp/v3/pkg/server"
 	log "github.com/sirupsen/logrus"
+	"google.golang.org/protobuf/types/known/anypb"
 )
 
 // NewServer creates, starts, and configures a new BGP server with configFile.

--- a/main.go
+++ b/main.go
@@ -63,7 +63,6 @@ func main() {
 	defer stop()
 	signal.Notify(bh.SigC, os.Signal(syscall.SIGUSR1))
 
-	log.WithFields(log.Fields{
-		"err": bh.UpdateRoutes(ctx),
-	}).Info("Server stopped")
+	log.WithError(bh.UpdateRoutes(ctx)).Info("Server stopped")
+
 }

--- a/parse.go
+++ b/parse.go
@@ -117,8 +117,8 @@ func parseFeeds(feeds ...string) (nets netcalc.Nets, totalNets int) {
 	return
 }
 
-// spamhausEntry represents a Spamhaus list entry.
-type spamhausEntry struct {
+// sblEntry represents a Spamhaus Block List entry.
+type sblEntry struct {
 	// IP network to drop, in CIDR format.
 	CIDR string `json:"cidr"`
 
@@ -135,7 +135,7 @@ func readFromJSON(r io.Reader, netC chan<- *net.IPNet) (int64, error) {
 	d := json.NewDecoder(r)
 	var i int64
 	for ; ; i++ {
-		var e spamhausEntry
+		var e sblEntry
 		err := d.Decode(&e)
 		if err == io.EOF {
 			break


### PR DESCRIPTION
Implements https://github.com/ebarkie/blackhole-threats/issues/9.

For now I think we can get away with detecting the format based on the response content type, so no need to specify it in the config.